### PR TITLE
feat(auth): 인증 인가 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.9.25'
-    id 'org.jetbrains.kotlin.plugin.spring' version '1.9.25'
-    id 'org.springframework.boot' version '3.5.5'
-    id 'io.spring.dependency-management' version '1.1.7'
-    id 'org.jetbrains.kotlin.plugin.jpa' version '1.9.25'
+    id "org.jetbrains.kotlin.jvm" version "1.9.25"
+    id "org.jetbrains.kotlin.plugin.spring" version "1.9.25"
+    id "org.springframework.boot" version "3.5.5"
+    id "io.spring.dependency-management" version "1.1.7"
+    id "org.jetbrains.kotlin.plugin.jpa" version "1.9.25"
 }
 
 group = 'io.jsween'
@@ -19,6 +19,7 @@ java {
 repositories {
     mavenCentral()
 }
+
 allprojects {
     apply {plugins}
     kotlin {
@@ -26,7 +27,6 @@ allprojects {
             freeCompilerArgs.addAll '-Xjsr305=strict'
         }
     }
-
     dependencies {
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
         implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -39,6 +39,9 @@ allprojects {
         testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
         runtimeOnly 'com.mysql:mysql-connector-j'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+        testImplementation "io.mockk:mockk:1.14.5"
+        // https://mvnrepository.com/artifact/org.assertj/assertj-core
+        testImplementation("org.assertj:assertj-core:3.27.4")
     }
 
     allOpen {

--- a/src/main/kotlin/io/jsween/ecommerce/adaptor/security/AuthorizationHeaderParser.kt
+++ b/src/main/kotlin/io/jsween/ecommerce/adaptor/security/AuthorizationHeaderParser.kt
@@ -1,0 +1,14 @@
+package io.jsween.ecommerce.adaptor.security
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.jsween.ecommerce.domain.auth.Authentication
+import org.springframework.stereotype.Component
+
+@Component
+class AuthorizationHeaderParser(val objectMapper: ObjectMapper) {
+    fun parse(header: String): Result<Authentication> {
+        return runCatching {
+            objectMapper.readValue(header, Authentication::class.java)
+        }
+    }
+}

--- a/src/main/kotlin/io/jsween/ecommerce/adaptor/web-api/filter/AuthenticationFilter.kt
+++ b/src/main/kotlin/io/jsween/ecommerce/adaptor/web-api/filter/AuthenticationFilter.kt
@@ -1,0 +1,31 @@
+package io.jsween.ecommerce.adaptor.`web-api`.filter
+
+import io.jsween.ecommerce.adaptor.security.AuthorizationHeaderParser
+import io.jsween.ecommerce.domain.auth.Authentication
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders.AUTHORIZATION
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class AuthenticationFilter(val authorizationHeaderParser: AuthorizationHeaderParser) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain
+    ) {
+        val header = request.getHeader(AUTHORIZATION)
+        if (header == null) {
+            request.setAttribute("authentication", Authentication.anonymous())
+        } else {
+            authorizationHeaderParser.parse(header)
+                .onFailure {
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED)
+                    return
+                }.onSuccess {
+                    request.setAttribute("authentication", it)
+                }
+        }
+        filterChain.doFilter(request, response)
+    }
+}

--- a/src/main/kotlin/io/jsween/ecommerce/adaptor/web-api/resolver/AuthenticationArgumentResolver.kt
+++ b/src/main/kotlin/io/jsween/ecommerce/adaptor/web-api/resolver/AuthenticationArgumentResolver.kt
@@ -1,0 +1,23 @@
+package io.jsween.ecommerce.adaptor.`web-api`.resolver
+
+import io.jsween.ecommerce.domain.auth.Authentication
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.core.MethodParameter
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+class AuthenticationArgumentResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.parameterType == Authentication::class.java
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): Authentication = webRequest.getNativeRequest(HttpServletRequest::class.java)
+        ?.getAttribute("authentication") as Authentication
+}

--- a/src/main/kotlin/io/jsween/ecommerce/adaptor/web-api/resolver/ResolverRegister.kt
+++ b/src/main/kotlin/io/jsween/ecommerce/adaptor/web-api/resolver/ResolverRegister.kt
@@ -1,0 +1,12 @@
+package io.jsween.ecommerce.adaptor.`web-api`.resolver
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class ResolverRegister : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver?>) {
+        resolvers.add(AuthenticationArgumentResolver())
+    }
+}

--- a/src/main/kotlin/io/jsween/ecommerce/domain/auth/Authentication.kt
+++ b/src/main/kotlin/io/jsween/ecommerce/domain/auth/Authentication.kt
@@ -1,0 +1,11 @@
+package io.jsween.ecommerce.domain.auth
+
+import java.util.*
+
+data class Authentication(val id: UUID, val roles: Set<Role>) {
+    companion object {
+        fun anonymous(): Authentication {
+            return Authentication(id = UUID.randomUUID(), roles = setOf(Role.ANONYMOUS))
+        }
+    }
+}

--- a/src/main/kotlin/io/jsween/ecommerce/domain/auth/Role.kt
+++ b/src/main/kotlin/io/jsween/ecommerce/domain/auth/Role.kt
@@ -1,0 +1,5 @@
+package io.jsween.ecommerce.domain.auth
+
+enum class Role {
+    ANONYMOUS, USER, ADMIN;
+}

--- a/src/test/kotlin/io/jsween/ecommerce/EcommerceApplicationTests.kt
+++ b/src/test/kotlin/io/jsween/ecommerce/EcommerceApplicationTests.kt
@@ -1,9 +1,8 @@
 package io.jsween.ecommerce
 
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
 
-@SpringBootTest
+@Integration
 class EcommerceApplicationTests {
 
     @Test

--- a/src/test/kotlin/io/jsween/ecommerce/Integration.kt
+++ b/src/test/kotlin/io/jsween/ecommerce/Integration.kt
@@ -1,0 +1,9 @@
+package io.jsween.ecommerce
+
+import io.mockk.junit5.MockKExtension
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(MockKExtension::class)
+annotation class Integration()

--- a/src/test/kotlin/io/jsween/ecommerce/adaptor/web-api/filter/AuthenticationFilterTest.kt
+++ b/src/test/kotlin/io/jsween/ecommerce/adaptor/web-api/filter/AuthenticationFilterTest.kt
@@ -1,0 +1,64 @@
+package io.jsween.ecommerce.adaptor.`web-api`.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.jsween.ecommerce.Integration
+import io.jsween.ecommerce.domain.auth.Authentication
+import io.jsween.ecommerce.domain.auth.Role
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import java.util.*
+
+
+@Integration
+class AuthenticationFilterTest @Autowired constructor(
+    private val objectMapper: ObjectMapper,
+    private val sut: AuthenticationFilter
+) {
+
+    @Test
+    fun `Authorization 헤더를 분석해 userId와 role을 취득한다`() {
+        //given
+        val authentication = Authentication(id = UUID.randomUUID(), roles = setOf(Role.USER))
+        val request = MockHttpServletRequest().apply {
+            addHeader("Authorization", objectMapper.writeValueAsString(authentication))
+        }
+        val response = MockHttpServletResponse()
+        val filterChain = MockFilterChain()
+        //when
+        sut.doFilter(request, response, filterChain)
+        //then
+        assertThat(request.getAttribute("authentication") as Authentication).isEqualTo(authentication)
+    }
+
+    @Test
+    fun `Authorization 헤더 분석에 실패하면 401 status를 반환한다`() {
+        //given
+        val request = MockHttpServletRequest().apply {
+            addHeader("Authorization", "wrong value")
+        }
+        val response = MockHttpServletResponse()
+        val filterChain = MockFilterChain()
+        //when
+        sut.doFilter(request, response, filterChain)
+        //then
+        assertThat(response.status).isEqualTo(HttpStatus.UNAUTHORIZED.value())
+    }
+
+    @Test
+    fun `Authorization 헤더가 비어있으면 Anonymous Authentication이 할당된다`() {
+        //given
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        val filterChain = MockFilterChain()
+        //when
+        sut.doFilter(request, response, filterChain)
+        //then
+        val actual = request.getAttribute("authentication") as Authentication
+        assertThat(actual.roles).isEqualTo(setOf(Role.ANONYMOUS))
+    }
+}

--- a/src/test/kotlin/io/jsween/ecommerce/adaptor/web-api/resolver/AuthenticationArgumentResolverTest.kt
+++ b/src/test/kotlin/io/jsween/ecommerce/adaptor/web-api/resolver/AuthenticationArgumentResolverTest.kt
@@ -1,0 +1,48 @@
+package io.jsween.ecommerce.adaptor.`web-api`.resolver
+
+import io.jsween.ecommerce.domain.auth.Authentication
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.core.MethodParameter
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.web.context.request.ServletWebRequest
+import org.springframework.web.method.support.ModelAndViewContainer
+
+class AuthenticationArgumentResolverTest {
+    private val authenticationArgumentResolver = AuthenticationArgumentResolver()
+
+    private inner class TestController() {
+        fun method1(authentication: Authentication) {
+
+        }
+        fun method2(authentication: String) {}
+    }
+
+    @Test
+    fun `파라미터가 authentication일 때 주입된다`() {
+        //given
+        val declaredMethod = TestController::class.java.getDeclaredMethod("method1", Authentication::class.java)
+        val param = MethodParameter(declaredMethod, 0)
+        val authentication = Authentication.anonymous()
+        val request = MockHttpServletRequest().apply { setAttribute("authentication", authentication) }
+        //when
+        val actual = authenticationArgumentResolver.resolveArgument(
+            param,
+            ModelAndViewContainer(),
+            ServletWebRequest(request),
+            null
+        )
+        //then
+        assertThat(actual).isEqualTo(authentication)
+    }
+
+    @Test
+    fun `파라미터가 authentication이 아니면 통과하지 못한다`() {
+        //given
+        val declaredMethod = TestController::class.java.getDeclaredMethod("method2", String::class.java)
+        val param = MethodParameter(declaredMethod, 0)
+        //when
+        //then
+        assertThat ( authenticationArgumentResolver.supportsParameter(param) ).isFalse
+    }
+}


### PR DESCRIPTION
- resolve #1 
# 개요
인증 인가를 구현합니다. 
회원가입 / 로그인 없이 진행합니다.


<img width="552" height="333" alt="스크린샷 2025-09-08 20 37 52" src="https://github.com/user-attachments/assets/8cb682e3-09be-4669-b05f-91179b4f611a" />
